### PR TITLE
Update dependencies for building on OS X

### DIFF
--- a/samples-aux/README.txt
+++ b/samples-aux/README.txt
@@ -47,8 +47,7 @@ Requires:
 * homebrew from http://brew.sh/
 
 At the terminal command line:
-$ brew install homebrew/science/opencv
-$ brew install sfml
+$ brew install sfml libusb
 
 Now you can run the pre-built binaries from the Astra SDK bin/ directory.
 


### PR DESCRIPTION
Just a small addition to the docs. I found that opencv isn't necessary to build the samples on OS X, but libusb was. Not sure if this needs to get added to other platforms as well...I'll leave that to you all :wink:

https://3dclub.orbbec3d.com/t/cant-run-samples-on-os-x/98/4?u=mattfelsen