### PR TITLE
Fix make_unique port on C++11 compilers

### DIFF
--- a/include/astra_core/astra_cxx_make_unique.hpp
+++ b/include/astra_core/astra_cxx_make_unique.hpp
@@ -96,14 +96,14 @@ namespace astra {
 #include <type_traits>
 #include <utility>
 
-namespace std {
+namespace astra {
 
 template<class _Ty> struct _Unique_if {
-   typedef unique_ptr<_Ty> _Single_object;
+   typedef std::unique_ptr<_Ty> _Single_object;
 };
 
 template<class _Ty> struct _Unique_if<_Ty[]> {
-   typedef unique_ptr<_Ty[]> _Unknown_bound;
+   typedef std::unique_ptr<_Ty[]> _Unknown_bound;
 };
 
 template<class _Ty, size_t N> struct _Unique_if<_Ty[N]> {
@@ -135,7 +135,7 @@ _VARIADIC_EXPAND_0X(_MAKE_UNIQUE, , , , )
 template<class _Ty, class... Args>
    typename _Unique_if<_Ty>::_Single_object
    make_unique(Args&&... args) {
-      return unique_ptr<_Ty>(new _Ty(std::forward<Args>(args)...));
+      return std::unique_ptr<_Ty>(new _Ty(std::forward<Args>(args)...));
    }
 
 #endif
@@ -146,8 +146,8 @@ template<class _Ty, class... Args>
 template<class _Ty>
    typename _Unique_if<_Ty>::_Unknown_bound
    make_unique(size_t n) {
-      typedef typename remove_extent<_Ty>::type U;
-      return unique_ptr<_Ty>(new U[n]());
+      typedef typename std::remove_extent<_Ty>::type U;
+      return std::unique_ptr<_Ty>(new U[n]());
    }
 
 // template< class T, class... Args >

--- a/src/astra_core/astra_cxx_make_unique.hpp
+++ b/src/astra_core/astra_cxx_make_unique.hpp
@@ -96,19 +96,20 @@ namespace astra {
 #include <type_traits>
 #include <utility>
 
-namespace std {
+namespace astra {
 
 template<class _Ty> struct _Unique_if {
-   typedef unique_ptr<_Ty> _Single_object;
+   typedef std::unique_ptr<_Ty> _Single_object;
 };
 
 template<class _Ty> struct _Unique_if<_Ty[]> {
-   typedef unique_ptr<_Ty[]> _Unknown_bound;
+   typedef std::unique_ptr<_Ty[]> _Unknown_bound;
 };
 
 template<class _Ty, size_t N> struct _Unique_if<_Ty[N]> {
    typedef void _Known_bound;
 };
+
 
 //
 // template< class T, class... Args >
@@ -135,7 +136,7 @@ _VARIADIC_EXPAND_0X(_MAKE_UNIQUE, , , , )
 template<class _Ty, class... Args>
    typename _Unique_if<_Ty>::_Single_object
    make_unique(Args&&... args) {
-      return unique_ptr<_Ty>(new _Ty(std::forward<Args>(args)...));
+      return std::unique_ptr<_Ty>(new _Ty(std::forward<Args>(args)...));
    }
 
 #endif
@@ -146,8 +147,8 @@ template<class _Ty, class... Args>
 template<class _Ty>
    typename _Unique_if<_Ty>::_Unknown_bound
    make_unique(size_t n) {
-      typedef typename remove_extent<_Ty>::type U;
-      return unique_ptr<_Ty>(new U[n]());
+      typedef typename std::remove_extent<_Ty>::type U;
+      return std::unique_ptr<_Ty>(new U[n]());
    }
 
 // template< class T, class... Args >
@@ -163,7 +164,7 @@ template<class T, class... Args>
 
 #endif
 
-} // namespace std
+} // namespace astra
 
 #endif // !COMPILER_SUPPORTS_MAKE_UNIQUE
 


### PR DESCRIPTION
This pull request fixes the C++11 make_unique port. On the current master I get:

```
gekko@orbbec:~/astra/build$ make
[  1%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyManager.c.o
[  2%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyNode.c.o
[  3%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyNodePool.c.o
[  4%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyNodeState.c.o
[  5%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyOutput.c.o
[  6%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyTools.c.o
[  7%] Building C object vendor/shinyprofiler/src/CMakeFiles/Shiny.dir/ShinyZone.c.o
[  8%] Linking C static library ../../../lib/libShiny.a
[  8%] Built target Shiny
[  9%] === LPP ===
=== LPP processing directory: ../include ===

=== LPP processing directory: ../src ===

[  9%] Built target ProxyPreprocessor
[  9%] Building CXX object src/astra_core_api/CMakeFiles/astra_core_api.dir/astra_core_api.cpp.o
[ 10%] Linking CXX shared library ../../lib/libastra_core_api.so
[ 10%] Built target astra_core_api
Scanning dependencies of target astra_core
[ 11%] Building CXX object src/astra_core/CMakeFiles/astra_core.dir/astra_context.cpp.o
/home/gekko/astra/src/astra_core/astra_context.cpp: In constructor ‘astra::context::context()’:
/home/gekko/astra/src/astra_core/astra_context.cpp:27:19: error: ‘make_unique’ is not a member of ‘astra’
           : impl_(astra::make_unique<context_impl>()),
                   ^
/home/gekko/astra/src/astra_core/astra_context.cpp:27:19: note: suggested alternative:
In file included from /home/gekko/astra/src/astra_core/astra_cxx_compatibility.hpp:20:0,
                 from /home/gekko/astra/src/astra_core/astra_context.cpp:20:
/home/gekko/astra/src/astra_core/astra_cxx_make_unique.hpp:162:4: note:   ‘std::make_unique’
    make_unique(Args&&...) = delete;
    ^
/home/gekko/astra/src/astra_core/astra_context.cpp:27:50: error: expected primary-expression before ‘>’ token
           : impl_(astra::make_unique<context_impl>()),
                                                  ^
/home/gekko/astra/src/astra_core/astra_context.cpp:27:52: error: expected primary-expression before ‘)’ token
           : impl_(astra::make_unique<context_impl>()),
                                                    ^
make[2]: *** [src/astra_core/CMakeFiles/astra_core.dir/astra_context.cpp.o] Error 1
make[1]: *** [src/astra_core/CMakeFiles/astra_core.dir/all] Error 2
make: *** [all] Error 2


gekko@orbbec:~/astra/build$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/arm-linux-gnueabihf/4.8/lto-wrapper
Target: arm-linux-gnueabihf
Configured with: ../src/configure -v --with-pkgversion='Ubuntu/Linaro 4.8.4-2ubuntu1~14.04.3' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --disable-libitm --disable-libquadmath --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-armhf/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-armhf --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-armhf --with-arch-directory=arm --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --enable-multilib --disable-sjlj-exceptions --with-arch=armv7-a --with-fpu=vfpv3-d16 --with-float=hard --with-mode=thumb --disable-werror --enable-checking=release --build=arm-linux-gnueabihf --host=arm-linux-gnueabihf --target=arm-linux-gnueabihf
Thread model: posix
gcc version 4.8.4 (Ubuntu/Linaro 4.8.4-2ubuntu1~14.04.3)
gekko@orbbec:~/astra/build$
```

This is on the Orbbec Persee Ubuntu 14 image.

The fixes:

* Add missing namespace
* Remove `namespace std` which caused unique_ptr and remove_extent to not be found
* Prepend `std::` in front of `unique_ptr` and `remove_extent`