### PR TITLE
Don't use double colon syntax for C enums

### DIFF
--- a/include/astra/capi/streams/image_capi.h
+++ b/include/astra/capi/streams/image_capi.h
@@ -77,28 +77,28 @@ inline void astra_pixelformat_get_bytes_per_pixel(astra_pixel_format_t format,
 {
     switch(format)
     {
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
+    case ASTRA_PIXEL_FORMAT_RGB888:
         *bpp = 3;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUV422:
+    case ASTRA_PIXEL_FORMAT_YUV422:
         *bpp = 2;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY8:
+    case ASTRA_PIXEL_FORMAT_GRAY8:
         *bpp = 1;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY16:
+    case ASTRA_PIXEL_FORMAT_GRAY16:
         *bpp = 2;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_DEPTH_MM:
+    case ASTRA_PIXEL_FORMAT_DEPTH_MM:
         *bpp = 2;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_UNKNOWN:
+    case ASTRA_PIXEL_FORMAT_UNKNOWN:
         *bpp = 1;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUYV:
+    case ASTRA_PIXEL_FORMAT_YUYV:
         *bpp = 2;
         break;
-    case astra_pixel_formats::ASTRA_PIXEL_FORMAT_POINT:
+    case ASTRA_PIXEL_FORMAT_POINT:
         *bpp = 12;
         break;
     default:


### PR DESCRIPTION
The C API has invalid syntax for accessing enums. Double colon enum access is a feature of C++.

Minimal example showing the problem:

```
#include <astra/capi/astra.h>
#include <astra/capi/streams/image_capi.h>

int main(int argc, char** argv)
{
    return 0;
}
```

Compile with:

```
gekko@gekkoslovakia-laptop:~/delicode/astra/samples/c-api/doublecolon$ gcc main.c -I/home/gekko/astra/include
In file included from main.c:2:0:
/home/gekko/astra/include/astra/capi/streams/image_capi.h: In function ‘astra_pixelformat_get_bytes_per_pixel’:
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:83:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUV422:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:83:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:83:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUV422:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:86:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY8:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:86:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:86:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY8:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:89:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY16:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:89:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^                                                                                                                                                                              [0/406]
/home/gekko/astra/include/astra/capi/streams/image_capi.h:89:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_GRAY16:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:92:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_DEPTH_MM:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:92:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:92:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_DEPTH_MM:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:95:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_UNKNOWN:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:95:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:95:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_UNKNOWN:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:98:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUYV:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:98:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:98:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_YUYV:
                              ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:101:10: error: expected expression before ‘astra_pixel_formats’
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_POINT:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:101:10: error: duplicate label ‘astra_pixel_formats’
/home/gekko/astra/include/astra/capi/streams/image_capi.h:80:10: note: previous definition of ‘astra_pixel_formats’ was here
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_RGB888:
          ^
/home/gekko/astra/include/astra/capi/streams/image_capi.h:101:30: error: expected expression before ‘:’ token
     case astra_pixel_formats::ASTRA_PIXEL_FORMAT_POINT:
                              ^
```

The fix is to remove the double colons.