### PR TITLE
Default CMakeLists.txt build type to release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ set (Astra_VERSION_MINOR 5)
 set (Astra_VERSION_PATCH 0)
 set (Astra_VERSION_BUILD 0)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release"
+    CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." 
+    FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(ASTRA_CLANG ON)
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
Not specifying `-DCMAKE_BUILD_TYPE=Release` seems to produce the following in the generated CMakeCache.txt: `CMakeCache.txt:46:CMAKE_BUILD_TYPE:STRING=`

Specifying either build type adds either Release or Debug in that variable. Release build type should be the default if debug isn't specified.