### PR TITLE
Modified the project so it will compile.

### DIFF
--- a/lpp/cl-fad/fad.lisp
+++ b/lpp/cl-fad/fad.lisp
@@ -306,7 +306,7 @@ might be removed instead!  This is currently fixed for SBCL and CCL."
                                     (unless ok
                                       (error "~@<Error deleting ~S: ~A~@:>"
                                              file (unix:get-unix-error-msg errno))))
-                           #+:clisp (ext:delete-dir file)
+                           #+:clisp (ext:delete-directory file)
                            #+:openmcl (cl-fad-ccl:delete-directory file)
                            #+:cormanlisp (win32:delete-directory file)
                            #+:ecl (si:rmdir file)

--- a/src/astra_core/astra_plugin_service.hpp
+++ b/src/astra_core/astra_plugin_service.hpp
@@ -21,6 +21,7 @@
 #include <astra_core/capi/astra_types.h>
 #include <astra_core/capi/plugins/astra_plugin_callbacks.h>
 #include <memory>
+#include <stdarg.h>
 
 using CallbackId = size_t;
 


### PR DESCRIPTION
The project failed to compile because of stdarg.h not being used, and a change in the name of the function that removes directories in the lisp script.